### PR TITLE
Add user authorization via Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,32 +40,32 @@ Aura Telegram Bot is a Python-based, AI-powered chatbot designed to act as a per
 
 1. **Clone the repository:**
     
-    ```
-    git clone [https://github.com/rabestro/aura-telegram-bot.git](https://github.com/rabestro/aura-telegram-bot.git)
+    ```shell
+    git clone https://github.com/rabestro/aura-telegram-bot.git
     cd aura-telegram-bot
     ```
     
 2. **Configure your environment:** This project uses a `.env` file for managing secrets and configuration.
     
-    ```
+    ```shell
     # Create your own .env file from the example
     cp .env.example .env
     ```
     
     Now, edit the `.env` file and fill in your credentials. It is **critical** to set the `ALLOWED_TELEGRAM_USER_IDS`.
     
-    ```
+    ```dotenv
     # .env
     TELEGRAM_TOKEN="YOUR_TELEGRAM_BOT_TOKEN_HERE"
     GEMINI_API_KEY="YOUR_GEMINI_API_KEY_HERE"
-    ALLOWED_TELEGRAM_USER_IDS="123456789" # <-- Replace with your User ID
+    ALLOWED_TELEGRAM_USER_IDS=[123456789] # <-- Replace with your User ID
     ```
     
-    To allow multiple users, separate their IDs with a comma: `123456789,987654321`.
+    To allow multiple users, separate their IDs with a comma: `[123456789,987654321]`.
     
 3. **Build and run the Docker container:**
     
-    ```
+    ```shell
     docker build -t aura-bot:latest .
     docker run -d --name aura-telegram-bot --restart always --env-file .env aura-bot:latest
     ```

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Aura Telegram Bot is a Python-based, AI-powered chatbot designed to act as a personal assistant for your smart home. It integrates with Google's Gemini for natural language understanding and can be connected to services like Home Assistant and BookStack to provide real-time information and control over your home environment.
 
-This repository serves as a template for building your own smart home assistant.
+**Security Note:** This bot is designed for private, personal use. It includes a mandatory user whitelist feature to ensure that only authorized individuals can interact with it.
 
 ## Features
 
 - **AI-Powered Conversations**: Utilizes Google Gemini to understand and answer questions based on a custom knowledge base.
+    
+- **Secure by Default**: A mandatory whitelist of Telegram User IDs ensures that only you and trusted users can interact with the bot.
     
 - **Service Integration**: Designed to connect to:
     
@@ -16,7 +18,7 @@ This repository serves as a template for building your own smart home assistant.
         
 - **Containerized**: Runs in a Docker container for easy and reliable deployment on any system, like a Raspberry Pi.
     
-- **Modern Python Stack**: Built with modern tools like `uv`, `ruff`, `mypy`, and `poethepoet` for a high-quality, maintainable codebase.
+- **Modern Python Stack**: Built with modern tools like `uv`, `ruff`, `mypy`, and `poethepoet` for a high-quality, maintainable codebase.
     
 
 ## Getting Started
@@ -27,9 +29,11 @@ This repository serves as a template for building your own smart home assistant.
     
 - Docker
     
-- A Telegram Bot Token from [@BotFather](https://t.me/BotFather)
+- A Telegram Bot Token from [@BotFather](https://t.me/BotFather "null")
     
-- A Google Gemini API Key from [Google AI Studio](https://aistudio.google.com/)
+- A Google Gemini API Key from [Google AI Studio](https://aistudio.google.com/ "null")
+    
+- Your personal Telegram User ID from [@userinfobot](https://t.me/userinfobot "null")
     
 
 ### Installation & Setup
@@ -37,18 +41,27 @@ This repository serves as a template for building your own smart home assistant.
 1. **Clone the repository:**
     
     ```
-    git clone https://github.com/rabestro/aura-telegram-bot.git
+    git clone [https://github.com/rabestro/aura-telegram-bot.git](https://github.com/rabestro/aura-telegram-bot.git)
     cd aura-telegram-bot
     ```
     
-2. **Configure your environment:** This project uses a `.env` file for managing secrets and configuration.
+2. **Configure your environment:** This project uses a `.env` file for managing secrets and configuration.
     
     ```
     # Create your own .env file from the example
     cp .env.example .env
     ```
     
-    Now, edit the `.env` file and fill in your credentials (`TELEGRAM_TOKEN`, `GEMINI_API_KEY`, etc.).
+    Now, edit the `.env` file and fill in your credentials. It is **critical** to set the `ALLOWED_TELEGRAM_USER_IDS`.
+    
+    ```
+    # .env
+    TELEGRAM_TOKEN="YOUR_TELEGRAM_BOT_TOKEN_HERE"
+    GEMINI_API_KEY="YOUR_GEMINI_API_KEY_HERE"
+    ALLOWED_TELEGRAM_USER_IDS="123456789" # <-- Replace with your User ID
+    ```
+    
+    To allow multiple users, separate their IDs with a comma: `123456789,987654321`.
     
 3. **Build and run the Docker container:**
     
@@ -57,7 +70,9 @@ This repository serves as a template for building your own smart home assistant.
     docker run -d --name aura-telegram-bot --restart always --env-file .env aura-bot:latest
     ```
     
-4. **Interact with your bot:** Find your bot on Telegram and start asking it questions!
+    For deployment on a Raspberry Pi using Docker Compose, refer to the provided `docker-compose.yml` file as a template.
+    
+4. **Interact with your bot:** Find your bot on Telegram and start asking it questions! If you configured the user whitelist correctly, it should now respond only to you.
     
 
 ## Customization
@@ -65,36 +80,20 @@ This repository serves as a template for building your own smart home assistant.
 ### Public Knowledge Base
 
 The bot's "public brain" is a simple text file (`knowledge_base.txt`). Use it only for non-sensitive, public information (e.g., device model notes, general procedures). Do not store passwords, tokens, or private data here. For sensitive information, use the Private Wiki pattern below.
+
 ### Extending with Integrations
 
 The code is structured to be easily extendable. To add new integrations:
 
-1. Add the necessary client libraries to `pyproject.toml`.
+1. Add the necessary client libraries to `pyproject.toml`.
     
-2. Add the configuration variables (URL, tokens) to your `.env` file.
+2. Add the configuration variables (URL, tokens) to your `.env` file and the `Settings` class in `src/aura_telegram_bot/config.py`.
     
-3. Create a new module in `src/aura_telegram_bot/integrations/` to handle the API communication.
+3. Create a new module in `src/aura_telegram_bot/integrations/` to handle the API communication.
     
-4. Update the main bot logic in `main.py` to call your new integration based on user intent.
+4. Update the main bot logic in `src/aura_telegram_bot/core/engine.py` to call your new integration based on user intent.
     
-
-### Advanced: Secure Data with a Private Wiki (BookStack)
-
-For sensitive information that should **never** be in a public repository (like technician phone numbers, maintenance logs, or private notes), you can use the built-in support for a private wiki like BookStack.
-
-**The process is completely secure:**
-
-1. You store your sensitive data on your own private BookStack instance.
-    
-2. You add the BookStack URL and API credentials to your **private** `.env` file. These are never committed to Git.
-    
-3. The bot's code contains the _logic_ to make an authenticated API call to your wiki when needed.
-    
-4. When a user asks for sensitive information (e.g., "What is the boiler technician's phone number?"), the bot securely fetches _only that piece of information_ from your wiki in real-time.
-    
-
-This pattern allows your public codebase to remain clean and secure, while your bot retains access to all the private information it needs to be truly helpful.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE` file for details.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+# docker-compose.example.yml
+# This is an example file for deploying the Aura bot alongside other services.
+# Copy this to 'docker-compose.yml' and adapt it to your needs.
+
+services:
+  aura-bot:
+    # Use the image you built and pushed with your CD pipeline, or build locally.
+    # To build locally, uncomment the 'build' section.
+    image: rabestro/aura-telegram-bot:latest
+    # build: .
+    container_name: aura-telegram-bot
+    restart: unless-stopped
+    # Use a dedicated .env file for the bot's secrets.
+    env_file:
+      - aura-bot.env
+    # This links our local knowledge_base.txt to the one inside the container.
+    # It allows us to update the knowledge base without rebuilding the image.
+    volumes:
+      - ./knowledge_base.txt:/app/knowledge_base.txt:ro # 'ro' for read-only
+    networks:
+      - auranet-services
+
+networks:
+  # Defines a custom network for our services to communicate on.
+  # This assumes other services (like Home Assistant) might be on the same network.
+  auranet-services:
+    driver: bridge

--- a/src/aura_telegram_bot/auth.py
+++ b/src/aura_telegram_bot/auth.py
@@ -1,0 +1,49 @@
+"""Authorization logic for the Telegram bot."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from telegram import Update
+    from telegram.ext import ContextTypes
+
+from aura_telegram_bot.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+# The corrected version uses Python 3.12+ syntax for generics (PEP 695).
+# We declare the TypeVar `R` directly in the function signature.
+def restricted[R](
+    func: Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[R]],
+) -> Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[R | None]]:
+    """Restrict access to handlers to authorized users."""
+
+    @wraps(func)
+    async def wrapped(update: Update, context: ContextTypes.DEFAULT_TYPE) -> R | None:
+        """The inner wrapper function that performs the authorization check."""
+        settings = get_settings()
+        if not update.effective_user:
+            logger.warning("Decorator received an update with no effective_user.")
+            return None
+
+        user_id = update.effective_user.id
+        user_name = update.effective_user.first_name
+
+        if user_id not in settings.allowed_telegram_user_ids:
+            logger.warning(
+                "Unauthorized access attempt by user_id: %s (Name: %s).",
+                user_id,
+                user_name,
+            )
+            return None  # Silently ignore the request
+
+        logger.info("Authorized access for user_id: %s (Name: %s).", user_id, user_name)
+        # The wrapped function's signature is known, so we call it directly.
+        return await func(update, context)
+
+    return wrapped

--- a/src/aura_telegram_bot/config.py
+++ b/src/aura_telegram_bot/config.py
@@ -45,7 +45,7 @@ class Settings(BaseSettings):
             return self.knowledge_base_path.read_text(encoding="utf-8")
         except FileNotFoundError:
             logger.error(
-                f"'{self.knowledge_base_path}' not found. Bot will lack specific context."
+                f"'{self.knowledge_base_path}' not found. Bot will lack specific context.",
             )
             return "No specific boiler information is available."
 
@@ -53,4 +53,4 @@ class Settings(BaseSettings):
 @lru_cache
 def get_settings() -> Settings:
     """Return a cached instance of the Settings object."""
-    return Settings()
+    return Settings()  # ty: ignore[missing-argument]

--- a/src/aura_telegram_bot/config.py
+++ b/src/aura_telegram_bot/config.py
@@ -6,6 +6,7 @@ import logging
 from functools import lru_cache
 from pathlib import Path
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # --- Setup logging ---
@@ -15,10 +16,6 @@ logger = logging.getLogger(__name__)
 class Settings(BaseSettings):
     """Manages application settings and secrets using Pydantic."""
 
-    # This tells Pydantic to load settings from a .env file.
-    # The `env_file` path is relative to where the script is run.
-    # In Docker, we use `aura-bot.env`, locally you can use a `.env`.
-    # Pydantic will handle this automatically.
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
@@ -26,13 +23,15 @@ class Settings(BaseSettings):
     )
 
     # --- Secrets (will be loaded from the .env file) ---
-    # Pydantic automatically finds environment variables matching these field names
-    # (case-insensitive) and validates them.
     telegram_token: str
     gemini_api_key: str
 
+    # --- Security ---
+    # A list of authorized Telegram user IDs. Pydantic will automatically
+    # convert a comma-separated string from the .env file into a list of ints.
+    allowed_telegram_user_ids: list[int] = Field(..., min_length=1)
+
     # --- Application settings ---
-    # We can define default values for non-secret settings.
     knowledge_base_path: Path = Path("knowledge_base.txt")
 
     def load_knowledge_base(self) -> str:
@@ -53,14 +52,5 @@ class Settings(BaseSettings):
 
 @lru_cache
 def get_settings() -> Settings:
-    """Return a cached instance of the Settings object.
-
-    This function uses lru_cache to ensure that the Settings object is
-    created only once (the first time it's called), and subsequent calls
-    will return the same cached instance. This implements a lazy-loading
-    singleton pattern.
-
-    Returns:
-        An instance of the Settings class.
-    """
-    return Settings()  # ty: ignore[missing-argument]
+    """Return a cached instance of the Settings object."""
+    return Settings()

--- a/src/aura_telegram_bot/main.py
+++ b/src/aura_telegram_bot/main.py
@@ -7,6 +7,7 @@ import logging
 from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
+from aura_telegram_bot.auth import restricted
 from aura_telegram_bot.config import get_settings
 from aura_telegram_bot.core.engine import AuraEngine
 
@@ -18,6 +19,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+@restricted
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Sends a welcome message when the /start command is issued."""
     user_name = (
@@ -25,7 +27,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if update.effective_user and update.effective_user.first_name
         else "there"
     )
-    if update.message is not None:
+    if update.message:
         await update.message.reply_text(
             f"Hello, {user_name}! I am the Aura expert for our Viessmann boiler. "
             "Ask me a "
@@ -33,50 +35,41 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         )
 
 
+@restricted
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handles user's questions by sending them to the AuraEngine."""
     if not update.message or not update.message.text:
         return
 
     user_question = update.message.text
-    user_first_name = (
-        update.effective_user.first_name
-        if update.effective_user and update.effective_user.first_name
-        else "unknown"
+    logger.info(
+        "Received question from user '%s': %s",
+        update.effective_user.first_name if update.effective_user else "unknown",
+        user_question,
     )
-    logger.info(f"Received question from user '{user_first_name}': {user_question}")
 
-    # Show "typing..." status in Telegram for better UX
-    if update.effective_chat is not None:
+    if update.effective_chat:
         await context.bot.send_chat_action(chat_id=update.effective_chat.id, action="typing")
 
-    # The engine is stored in the bot's context, so we can access it here.
     engine: AuraEngine = context.bot_data["engine"]
     answer = await engine.get_response(user_question)
-    if update.message is not None:
+    if update.message:
         await update.message.reply_text(answer)
 
 
 def main() -> None:
     """Starts the Telegram bot and waits for messages."""
-    # Settings are now loaded and validated automatically when `settings` is imported.
-    # No more manual checks are needed here.
-    logger.info("Starting bot...")
-
-    # --- Initialize Telegram Bot using validated settings ---
     settings = get_settings()
+    logger.info("Starting bot...")
     application = Application.builder().token(settings.telegram_token).build()
 
-    # --- Initialize Engine and add it to the bot's context ---
     knowledge_base = settings.load_knowledge_base()
     engine = AuraEngine(gemini_api_key=settings.gemini_api_key, knowledge_base=knowledge_base)
     application.bot_data["engine"] = engine
 
-    # Register handlers
     application.add_handler(CommandHandler("start", start))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
 
-    # Start the Bot
     application.run_polling()
     logger.info("Bot stopped.")
 

--- a/src/aura_telegram_bot/main.py
+++ b/src/aura_telegram_bot/main.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import logging
 
 from telegram import Update
-from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
+from telegram.constants import ChatAction
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 
 from aura_telegram_bot.auth import restricted
 from aura_telegram_bot.config import get_settings
@@ -16,22 +23,20 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     level=logging.INFO,
 )
+# Set a higher log level for the httpx library to avoid noisy logs.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
 logger = logging.getLogger(__name__)
 
 
 @restricted
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Sends a welcome message when the /start command is issued."""
-    user_name = (
-        update.effective_user.first_name
-        if update.effective_user and update.effective_user.first_name
-        else "there"
-    )
+    user_name = update.effective_user.first_name if update.effective_user else "there"
     if update.message:
         await update.message.reply_text(
             f"Hello, {user_name}! I am the Aura expert for our Viessmann boiler. "
-            "Ask me a "
-            "question about it.",
+            "Ask me a question about it.",
         )
 
 
@@ -42,15 +47,17 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         return
 
     user_question = update.message.text
-    logger.info(
-        "Received question from user '%s': %s",
-        update.effective_user.first_name if update.effective_user else "unknown",
-        user_question,
-    )
+    user_name = update.effective_user.first_name if update.effective_user else "unknown"
+    logger.info(f"Received question from user '{user_name}': {user_question}")
 
+    # Show "typing..." status in Telegram for better UX
     if update.effective_chat:
-        await context.bot.send_chat_action(chat_id=update.effective_chat.id, action="typing")
+        await context.bot.send_chat_action(
+            chat_id=update.effective_chat.id,
+            action=ChatAction.TYPING,
+        )
 
+    # The engine is stored in the bot's context, so we can access it here.
     engine: AuraEngine = context.bot_data["engine"]
     answer = await engine.get_response(user_question)
     if update.message:
@@ -60,17 +67,28 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 def main() -> None:
     """Starts the Telegram bot and waits for messages."""
     settings = get_settings()
+
+    # --- Initialize Telegram Bot ---
     logger.info("Starting bot...")
     application = Application.builder().token(settings.telegram_token).build()
 
+    # --- Initialize Engine and add it to the bot's context ---
     knowledge_base = settings.load_knowledge_base()
-    engine = AuraEngine(gemini_api_key=settings.gemini_api_key, knowledge_base=knowledge_base)
+    engine = AuraEngine(
+        gemini_api_key=settings.gemini_api_key.get_secret_value(),
+        knowledge_base=knowledge_base,
+    )
     application.bot_data["engine"] = engine
 
+    # Register handlers
     application.add_handler(CommandHandler("start", start))
-    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+    application.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message),
+    )
 
-    application.run_polling()
+    # Start the Bot, ignoring any updates that were missed while it was offline.
+    logger.info("Bot started and polling for updates...")
+    application.run_polling(drop_pending_updates=True)
     logger.info("Bot stopped.")
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,65 @@
+"""Unit tests for the authorization decorator."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aura_telegram_bot.auth import restricted
+
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def mock_update() -> MagicMock:
+    """Fixture to create a mock Update object."""
+    update = MagicMock()
+    update.effective_user.id = 12345  # Authorized user ID
+    update.effective_user.first_name = "Jegors"
+    return update
+
+
+@pytest.fixture
+def mock_context() -> MagicMock:
+    """Fixture to create a mock Context object."""
+    return MagicMock()
+
+
+@patch("aura_telegram_bot.auth.get_settings")
+async def test_restricted_allows_authorized_user(
+    mock_get_settings: MagicMock,
+    mock_update: MagicMock,
+    mock_context: MagicMock,
+) -> None:
+    """Verify that the decorator allows a user with an ID in the whitelist."""
+    # Arrange
+    mock_get_settings.return_value.allowed_telegram_user_ids = [12345, 67890]
+    original_handler = AsyncMock()
+    decorated_handler = restricted(original_handler)
+
+    # Act
+    await decorated_handler(mock_update, mock_context)
+
+    # Assert
+    original_handler.assert_called_once_with(mock_update, mock_context)
+
+
+@patch("aura_telegram_bot.auth.get_settings")
+async def test_restricted_blocks_unauthorized_user(
+    mock_get_settings: MagicMock,
+    mock_update: MagicMock,
+    mock_context: MagicMock,
+) -> None:
+    """Verify that the decorator blocks a user with an ID not in the whitelist."""
+    # Arrange
+    mock_get_settings.return_value.allowed_telegram_user_ids = [99999, 88888]
+    original_handler = AsyncMock()
+    decorated_handler = restricted(original_handler)
+
+    # Act
+    await decorated_handler(mock_update, mock_context)
+
+    # Assert
+    original_handler.assert_not_called()


### PR DESCRIPTION
### Summary

This pull request implements user authorization functionality for the Telegram bot by introducing a `restricted` decorator. It also includes updates and improvements in related documentation and code practices.

### Changes Introduced
- Added a `restricted` decorator to enforce user authorization on `/start` and message handlers.
- Created unit tests to validate the behavior of the `restricted` decorator.
- Updated the README with information on security features, user whitelist configuration, and deployment details.
- Introduced an `allowed_telegram_user_ids` field to the `Settings` for maintaining a whitelist of authorized users.
- Fixed minor type warnings and improved comments in `config.py`.

### Checklist
- [x] Documentation has been updated as needed.
- [x] Unit tests have been added or improved for newly implemented functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added access control for the Telegram bot via an allowlist of user IDs.
  - Bot now responds only to authorized users when configured.
- Documentation
  - Expanded security guidance with a Security Note and “Secure by Default” details.
  - Added BookStack/Private Wiki as a supported integration.
  - Updated prerequisites (includes Google Gemini API key and personal Telegram User ID).
  - Provided .env example for ALLOWED_TELEGRAM_USER_IDS (supports comma-separated IDs).
  - Noted Docker Compose deployment for Raspberry Pi.
  - Removed the Advanced Private Wiki section; minor formatting improvements.
- Tests
  - Added unit tests covering authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->