### PR TITLE
Fix `gemini_api_key` handling in `AuraEngine` initialization

### DIFF
--- a/src/aura_telegram_bot/main.py
+++ b/src/aura_telegram_bot/main.py
@@ -75,7 +75,7 @@ def main() -> None:
     # --- Initialize Engine and add it to the bot's context ---
     knowledge_base = settings.load_knowledge_base()
     engine = AuraEngine(
-        gemini_api_key=settings.gemini_api_key.get_secret_value(),
+        gemini_api_key=settings.gemini_api_key,
         knowledge_base=knowledge_base,
     )
     application.bot_data["engine"] = engine


### PR DESCRIPTION
Improper handling of the `gemini_api_key` within the initialization process of the `AuraEngine` has been addressed.