### PR TITLE
Add Home Assistant integration and related dependencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,4 +13,4 @@ HOME_ASSISTANT_TOKEN="YOUR_HA_LONG_LIVED_ACCESS_TOKEN"
 # A comma-separated list of Telegram User IDs who are allowed to use this bot.
 # Example: ALLOWED_TELEGRAM_USER_IDS=[123456789]
 # Example: ALLOWED_TELEGRAM_USER_IDS=[123456789,987654321]
-ALLOWED_TELEGRAM_USER_IDS=[]
+ALLOWED_TELEGRAM_USER_IDS=[123456789]  # Replace with your Telegram user ID(s)

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,16 @@
 # This is an example file. Copy it to .env and fill in your actual tokens.
 # The .env file should NOT be committed to git.
 
+# --- Telegram & AI ---
 TELEGRAM_TOKEN="YOUR_TELEGRAM_BOT_TOKEN_HERE"
 GEMINI_API_KEY="YOUR_GEMINI_API_KEY_HERE"
+
+# --- Integrations ---
+HOME_ASSISTANT_URL="http://homeassistant.local:8123"
+HOME_ASSISTANT_TOKEN="YOUR_HA_LONG_LIVED_ACCESS_TOKEN"
+
+# --- Security ---
+# A comma-separated list of Telegram User IDs who are allowed to use this bot.
+# Example: ALLOWED_TELEGRAM_USER_IDS=[123456789]
+# Example: ALLOWED_TELEGRAM_USER_IDS=[123456789,987654321]
+ALLOWED_TELEGRAM_USER_IDS=[]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ Repository = "https://github.com/rabestro/aura-telegram-bot.git"
 [project.optional-dependencies]
 dev = [
   "ruff", # Code linter and formatter
-  "mypy", # Static type checker
   "pytest", # Testing framework
   "pytest-asyncio", # For testing asynchronous code
   "poethepoet", # Task runner
+  "respx>=0.21", # HTTPX mocking for tests
 ]
 
 # ==============================================================================
@@ -113,16 +113,6 @@ required-imports = ["from __future__ import annotations"]
 quote-style = "double"
 indent-style = "space"
 line-ending = "lf"
-
-# --- MyPy (Type Checker) ---
-[tool.mypy]
-mypy_path = "src"
-strict = true
-
-# Ignore missing type stubs for the google-generativeai library
-[[tool.mypy.overrides]]
-module = "google.generativeai.*"
-ignore_missing_imports = true
 
 # --- Pytest (Testing Framework) ---
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "google-generativeai", # For integration with the Gemini AI API
   "python-dotenv",       # For loading secrets (tokens) from a .env file
   "pydantic-settings",   # For robust settings management
-  "httpx",               # Asynchronous HTTP client for API integrations
+  "httpx>=0.27,<1",      # Asynchronous HTTP client for API integrations
 ]
 
 [project.urls]
@@ -42,11 +42,11 @@ Repository = "https://github.com/rabestro/aura-telegram-bot.git"
 # ==============================================================================
 [project.optional-dependencies]
 dev = [
-  "ruff", # Code linter and formatter
-  "pytest", # Testing framework
-  "pytest-asyncio", # For testing asynchronous code
-  "poethepoet", # Task runner
-  "respx>=0.21", # HTTPX mocking for tests
+  "ruff",               # Code linter and formatter
+  "pytest",             # Testing framework
+  "pytest-asyncio",     # For testing asynchronous code
+  "poethepoet",         # Task runner
+  "respx>=0.22,<0.23",  # HTTPX mocking for tests (align with httpx pin)
 ]
 
 # ==============================================================================
@@ -132,6 +132,7 @@ if [ ! -f .env ]; then
     echo "⚠️  Warning: .env file not found. Creating a default one."
     echo "TELEGRAM_TOKEN='YOUR_TELEGRAM_BOT_TOKEN_HERE'" > .env
     echo "GEMINI_API_KEY='YOUR_GEMINI_API_KEY_HERE'" >> .env
+    echo "ALLOWED_TELEGRAM_USER_IDS=[123456789]" >> .env
     echo "Please fill in the .env file with your actual tokens."
 fi
 """
@@ -152,10 +153,6 @@ help = "🔍 Lint code for errors using Ruff"
 [tool.poe.tasks.fix]
 cmd = "ruff check src tests --fix --show-fixes"
 help = "✨ Automatically fix linter errors"
-
-[tool.poe.tasks.mypy]
-cmd = "mypy src/"
-help = "🧐 Check static types with mypy"
 
 [tool.poe.tasks.ty]
 cmd = "uvx ty check"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "google-generativeai", # For integration with the Gemini AI API
   "python-dotenv",       # For loading secrets (tokens) from a .env file
   "pydantic-settings",   # For robust settings management
+  "httpx",               # Asynchronous HTTP client for API integrations
 ]
 
 [project.urls]

--- a/src/aura_telegram_bot/config.py
+++ b/src/aura_telegram_bot/config.py
@@ -6,7 +6,7 @@ import logging
 from functools import lru_cache
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import Field, HttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # --- Setup logging ---
@@ -25,6 +25,10 @@ class Settings(BaseSettings):
     # --- Secrets (will be loaded from the .env file) ---
     telegram_token: str
     gemini_api_key: str
+    home_assistant_token: str
+
+    # --- URLs ---
+    home_assistant_url: HttpUrl
 
     # --- Security ---
     # A list of authorized Telegram user IDs. Pydantic will automatically

--- a/src/aura_telegram_bot/integrations/__init__.py
+++ b/src/aura_telegram_bot/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""This package contains modules for integrating with external services."""

--- a/src/aura_telegram_bot/integrations/home_assistant.py
+++ b/src/aura_telegram_bot/integrations/home_assistant.py
@@ -57,7 +57,8 @@ class HomeAssistantClient:
         url = urljoin(self._base_url, api_path)
         logger.info(f"Requesting entity state from: {url}")
 
-        async with httpx.AsyncClient() as client:
+        DEFAULT_TIMEOUT = httpx.Timeout(10.0)
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
             try:
                 response = await client.get(url, headers=self._headers)
                 response.raise_for_status()  # Raises HTTPStatusError for 4xx/5xx responses

--- a/src/aura_telegram_bot/integrations/home_assistant.py
+++ b/src/aura_telegram_bot/integrations/home_assistant.py
@@ -1,0 +1,74 @@
+"""A client for interacting with the Home Assistant REST API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+
+# --- Setup logging ---
+logger = logging.getLogger(__name__)
+
+
+class HomeAssistantError(Exception):
+    """Base exception for Home Assistant client errors."""
+
+
+class ApiError(HomeAssistantError):
+    """Raised when the API returns a non-200 status code."""
+
+
+class ConnectionError(HomeAssistantError):
+    """Raised when the client cannot connect to Home Assistant."""
+
+
+class HomeAssistantClient:
+    """An asynchronous client for the Home Assistant REST API."""
+
+    def __init__(self, base_url: str, token: str) -> None:
+        """Initializes the Home Assistant client.
+
+        Args:
+            base_url: The base URL of the Home Assistant instance (e.g., http://localhost:8123).
+            token: A long-lived access token for authentication.
+        """
+        self._base_url = base_url
+        self._headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    async def get_entity_state(self, entity_id: str) -> dict[str, Any]:
+        """Fetches the state of a specific entity from Home Assistant.
+
+        Args:
+            entity_id: The ID of the entity to fetch (e.g., "light.living_room").
+
+        Returns:
+            A dictionary representing the entity's state.
+
+        Raises:
+            ConnectionError: If there's a network issue connecting to Home Assistant.
+            ApiError: If Home Assistant returns an error response.
+        """
+        api_path = f"api/states/{entity_id}"
+        url = urljoin(self._base_url, api_path)
+        logger.info(f"Requesting entity state from: {url}")
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(url, headers=self._headers)
+                response.raise_for_status()  # Raises HTTPStatusError for 4xx/5xx responses
+                return response.json()
+            except httpx.RequestError as e:
+                logger.error(f"Failed to connect to Home Assistant at {url}: {e}")
+                raise ConnectionError(f"Cannot connect to Home Assistant: {e}") from e
+            except httpx.HTTPStatusError as e:
+                logger.error(
+                    f"Received non-200 response from Home Assistant: {e.response.status_code}",
+                )
+                raise ApiError(
+                    f"Home Assistant API returned status {e.response.status_code}",
+                ) from e

--- a/tests/integrations/test_home_assistant.py
+++ b/tests/integrations/test_home_assistant.py
@@ -11,7 +11,7 @@ from httpx import Response
 
 from aura_telegram_bot.integrations.home_assistant import (
     ApiError,
-    ConnectionError,
+    HAConnectionError,
     HomeAssistantClient,
 )
 
@@ -73,7 +73,7 @@ async def test_get_entity_state_api_error(client: HomeAssistantClient) -> None:
 
 @respx.mock
 async def test_get_entity_state_connection_error(client: HomeAssistantClient) -> None:
-    """Verify that ConnectionError is raised on network issues."""
+    """Verify that HAConnectionError is raised on network issues."""
     # Arrange
     # Mock a network-level error, like a timeout or DNS failure
     request = respx.get(f"{TEST_URL}/api/states/{TEST_ENTITY_ID}").mock(
@@ -81,7 +81,7 @@ async def test_get_entity_state_connection_error(client: HomeAssistantClient) ->
     )
 
     # Act & Assert
-    with pytest.raises(ConnectionError, match="Cannot connect to Home Assistant"):
+    with pytest.raises(HAConnectionError, match="Cannot connect to Home Assistant"):
         await client.get_entity_state(TEST_ENTITY_ID)
 
     assert request.called

--- a/tests/integrations/test_home_assistant.py
+++ b/tests/integrations/test_home_assistant.py
@@ -1,0 +1,87 @@
+"""Unit tests for the HomeAssistantClient."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from httpx import Response
+
+from aura_telegram_bot.integrations.home_assistant import (
+    ApiError,
+    ConnectionError,
+    HomeAssistantClient,
+)
+
+# Constants for testing
+TEST_URL = "http://fake-home-assistant.local:8123"
+TEST_TOKEN = "fake-long-lived-token"  # noqa: S105
+TEST_ENTITY_ID = "light.living_room_lamp"
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def client() -> HomeAssistantClient:
+    """Provides a HomeAssistantClient instance for testing."""
+    return HomeAssistantClient(base_url=TEST_URL, token=TEST_TOKEN)
+
+
+@respx.mock
+async def test_get_entity_state_success(client: HomeAssistantClient) -> None:
+    """Verify a successful API call to get an entity's state."""
+    # Arrange
+    # Mock the expected API response from Home Assistant
+    expected_state: dict[str, Any] = {
+        "entity_id": TEST_ENTITY_ID,
+        "state": "on",
+        "attributes": {"friendly_name": "Living Room Lamp"},
+    }
+    request = respx.get(f"{TEST_URL}/api/states/{TEST_ENTITY_ID}").mock(
+        return_value=Response(200, json=expected_state),
+    )
+
+    # Act
+    actual_state = await client.get_entity_state(TEST_ENTITY_ID)
+
+    # Assert
+    assert request.called
+    assert actual_state == expected_state
+    # Verify that the correct headers were sent
+    sent_headers = request.calls.last.request.headers
+    assert sent_headers["authorization"] == f"Bearer {TEST_TOKEN}"
+    assert sent_headers["content-type"] == "application/json"
+
+
+@respx.mock
+async def test_get_entity_state_api_error(client: HomeAssistantClient) -> None:
+    """Verify that ApiError is raised for non-200 responses."""
+    # Arrange
+    # Mock a 404 Not Found response
+    request = respx.get(f"{TEST_URL}/api/states/{TEST_ENTITY_ID}").mock(
+        return_value=Response(404),
+    )
+
+    # Act & Assert
+    with pytest.raises(ApiError, match="Home Assistant API returned status 404"):
+        await client.get_entity_state(TEST_ENTITY_ID)
+
+    assert request.called
+
+
+@respx.mock
+async def test_get_entity_state_connection_error(client: HomeAssistantClient) -> None:
+    """Verify that ConnectionError is raised on network issues."""
+    # Arrange
+    # Mock a network-level error, like a timeout or DNS failure
+    request = respx.get(f"{TEST_URL}/api/states/{TEST_ENTITY_ID}").mock(
+        side_effect=httpx.ConnectError("Connection failed"),
+    )
+
+    # Act & Assert
+    with pytest.raises(ConnectionError, match="Cannot connect to Home Assistant"):
+        await client.get_entity_state(TEST_ENTITY_ID)
+
+    assert request.called

--- a/uv.lock
+++ b/uv.lock
@@ -52,14 +52,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "google-generativeai" },
-    { name = "httpx" },
+    { name = "httpx", specifier = ">=0.27,<1" },
     { name = "poethepoet", marker = "extra == 'dev'" },
     { name = "pydantic-settings" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
-    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22,<0.23" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,7 @@ name = "aura-telegram-bot"
 source = { editable = "." }
 dependencies = [
     { name = "google-generativeai" },
+    { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
@@ -51,6 +52,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "google-generativeai" },
+    { name = "httpx" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "poethepoet", marker = "extra == 'dev'" },
     { name = "pydantic-settings" },

--- a/uv.lock
+++ b/uv.lock
@@ -42,10 +42,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "mypy" },
     { name = "poethepoet" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -53,13 +53,13 @@ dev = [
 requires-dist = [
     { name = "google-generativeai" },
     { name = "httpx" },
-    { name = "mypy", marker = "extra == 'dev'" },
     { name = "poethepoet", marker = "extra == 'dev'" },
     { name = "pydantic-settings" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
@@ -353,47 +353,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/22/ea637422dedf0bf36f3ef238eab4e455e2a0dcc3082b5cc067615347ab8e/mypy-1.17.1.tar.gz", hash = "sha256:25e01ec741ab5bb3eec8ba9cdb0f769230368a22c959c4937360efb89b7e9f01", size = 3352570, upload-time = "2025-07-31T07:54:19.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/a2/7034d0d61af8098ec47902108553122baa0f438df8a713be860f7407c9e6/mypy-1.17.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:69e83ea6553a3ba79c08c6e15dbd9bfa912ec1e493bf75489ef93beb65209aeb", size = 11086295, upload-time = "2025-07-31T07:53:28.124Z" },
-    { url = "https://files.pythonhosted.org/packages/14/1f/19e7e44b594d4b12f6ba8064dbe136505cec813549ca3e5191e40b1d3cc2/mypy-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b16708a66d38abb1e6b5702f5c2c87e133289da36f6a1d15f6a5221085c6403", size = 10112355, upload-time = "2025-07-31T07:53:21.121Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/69/baa33927e29e6b4c55d798a9d44db5d394072eef2bdc18c3e2048c9ed1e9/mypy-1.17.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89e972c0035e9e05823907ad5398c5a73b9f47a002b22359b177d40bdaee7056", size = 11875285, upload-time = "2025-07-31T07:53:55.293Z" },
-    { url = "https://files.pythonhosted.org/packages/90/13/f3a89c76b0a41e19490b01e7069713a30949d9a6c147289ee1521bcea245/mypy-1.17.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03b6d0ed2b188e35ee6d5c36b5580cffd6da23319991c49ab5556c023ccf1341", size = 12737895, upload-time = "2025-07-31T07:53:43.623Z" },
-    { url = "https://files.pythonhosted.org/packages/23/a1/c4ee79ac484241301564072e6476c5a5be2590bc2e7bfd28220033d2ef8f/mypy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c837b896b37cd103570d776bda106eabb8737aa6dd4f248451aecf53030cdbeb", size = 12931025, upload-time = "2025-07-31T07:54:17.125Z" },
-    { url = "https://files.pythonhosted.org/packages/89/b8/7409477be7919a0608900e6320b155c72caab4fef46427c5cc75f85edadd/mypy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:665afab0963a4b39dff7c1fa563cc8b11ecff7910206db4b2e64dd1ba25aed19", size = 9584664, upload-time = "2025-07-31T07:54:12.842Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/82/aec2fc9b9b149f372850291827537a508d6c4d3664b1750a324b91f71355/mypy-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93378d3203a5c0800c6b6d850ad2f19f7a3cdf1a3701d3416dbf128805c6a6a7", size = 11075338, upload-time = "2025-07-31T07:53:38.873Z" },
-    { url = "https://files.pythonhosted.org/packages/07/ac/ee93fbde9d2242657128af8c86f5d917cd2887584cf948a8e3663d0cd737/mypy-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:15d54056f7fe7a826d897789f53dd6377ec2ea8ba6f776dc83c2902b899fee81", size = 10113066, upload-time = "2025-07-31T07:54:14.707Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/68/946a1e0be93f17f7caa56c45844ec691ca153ee8b62f21eddda336a2d203/mypy-1.17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:209a58fed9987eccc20f2ca94afe7257a8f46eb5df1fb69958650973230f91e6", size = 11875473, upload-time = "2025-07-31T07:53:14.504Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/0f/478b4dce1cb4f43cf0f0d00fba3030b21ca04a01b74d1cd272a528cf446f/mypy-1.17.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:099b9a5da47de9e2cb5165e581f158e854d9e19d2e96b6698c0d64de911dd849", size = 12744296, upload-time = "2025-07-31T07:53:03.896Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/70/afa5850176379d1b303f992a828de95fc14487429a7139a4e0bdd17a8279/mypy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa6ffadfbe6994d724c5a1bb6123a7d27dd68fc9c059561cd33b664a79578e14", size = 12914657, upload-time = "2025-07-31T07:54:08.576Z" },
-    { url = "https://files.pythonhosted.org/packages/53/f9/4a83e1c856a3d9c8f6edaa4749a4864ee98486e9b9dbfbc93842891029c2/mypy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:9a2b7d9180aed171f033c9f2fc6c204c1245cf60b0cb61cf2e7acc24eea78e0a", size = 9593320, upload-time = "2025-07-31T07:53:01.341Z" },
-    { url = "https://files.pythonhosted.org/packages/38/56/79c2fac86da57c7d8c48622a05873eaab40b905096c33597462713f5af90/mypy-1.17.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:15a83369400454c41ed3a118e0cc58bd8123921a602f385cb6d6ea5df050c733", size = 11040037, upload-time = "2025-07-31T07:54:10.942Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/c3/adabe6ff53638e3cad19e3547268482408323b1e68bf082c9119000cd049/mypy-1.17.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:55b918670f692fc9fba55c3298d8a3beae295c5cded0a55dccdc5bbead814acd", size = 10131550, upload-time = "2025-07-31T07:53:41.307Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c5/2e234c22c3bdeb23a7817af57a58865a39753bde52c74e2c661ee0cfc640/mypy-1.17.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:62761474061feef6f720149d7ba876122007ddc64adff5ba6f374fda35a018a0", size = 11872963, upload-time = "2025-07-31T07:53:16.878Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/26/c13c130f35ca8caa5f2ceab68a247775648fdcd6c9a18f158825f2bc2410/mypy-1.17.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c49562d3d908fd49ed0938e5423daed8d407774a479b595b143a3d7f87cdae6a", size = 12710189, upload-time = "2025-07-31T07:54:01.962Z" },
-    { url = "https://files.pythonhosted.org/packages/82/df/c7d79d09f6de8383fe800521d066d877e54d30b4fb94281c262be2df84ef/mypy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:397fba5d7616a5bc60b45c7ed204717eaddc38f826e3645402c426057ead9a91", size = 12900322, upload-time = "2025-07-31T07:53:10.551Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/98/3d5a48978b4f708c55ae832619addc66d677f6dc59f3ebad71bae8285ca6/mypy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:9d6b20b97d373f41617bd0708fd46aa656059af57f2ef72aa8c7d6a2b73b74ed", size = 9751879, upload-time = "2025-07-31T07:52:56.683Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/f3/8fcd2af0f5b806f6cf463efaffd3c9548a28f84220493ecd38d127b6b66d/mypy-1.17.1-py3-none-any.whl", hash = "sha256:a9f52c0351c21fe24c21d8c0eb1f62967b262d6729393397b6f443c3b773c3b9", size = 2283411, upload-time = "2025-07-31T07:53:24.664Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -409,15 +368,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/f1/4594f5e0fcddb6953e5b8fe00da8c317b8b41b547e2b3ae2da7512943c62/pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d", size = 7555, upload-time = "2020-09-16T19:21:12.43Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/18/a8444036c6dd65ba3624c63b734d3ba95ba63ace513078e1580590075d21/pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364", size = 5955, upload-time = "2020-09-16T19:21:11.409Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
@@ -666,6 +616,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
---

### Summary

This pull request introduces the following changes:

- Adds `HomeAssistantClient` integration for fetching entity states via the Home Assistant REST API.
- Implements support for `home_assistant_token` and `home_assistant_url` in the configuration to enable Home Assistant integration.
- Includes `httpx` as a dependency for asynchronous API integration.
- Adds `respx` as a testing dependency for simulating HTTP requests.
- Adds unit tests for the Home Assistant integration.
- Updates `.env.example` with new configuration variables for integrations and security considerations.
- Adds a package docstring for `aura_telegram_bot.integrations`.

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have added appropriate tests where necessary.
- [x] I have updated documentation where relevant.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have added any relevant environment variables to the `.env.example` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home Assistant integration added: async client to fetch entity states and new validated settings for HA URL and token.
* **Documentation**
  * Expanded example environment variables for Telegram, AI keys, Home Assistant, and allowed Telegram user IDs.
  * Added a short description for the integrations package.
* **Tests**
  * Unit tests covering success, API error, and connection error scenarios for the Home Assistant integration.
* **Chores**
  * Added httpx runtime dependency and respx for tests; removed mypy and its configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->